### PR TITLE
lowered minSdkVersion to 16 for now

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,7 +44,7 @@ android {
 
     defaultConfig {
         applicationId 'com.cephalon.navis'
-        minSdkVersion 18
+        minSdkVersion 16
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Some people sill use Android 4.X so for now I'll support it, until Google Play service ends support for it. Unless I see that flutter no longer works for those devices